### PR TITLE
Upgrades js-yaml to ^3.13.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "extract-text-webpack-plugin": "^3.0.2",
     "file-loader": "^1.1.11",
     "glob": "^7.1.2",
-    "js-yaml": "^3.13.0",
+    "js-yaml": "^3.13.1",
     "node-sass": "^4.9.2",
     "optimize-css-assets-webpack-plugin": "^3.2.0",
     "path-complete-extname": "^1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3442,10 +3442,10 @@ js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
 
-js-yaml@^3.13.0:
-  version "3.13.0"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.0.tgz#38ee7178ac0eea2c97ff6d96fff4b18c7d8cf98e"
-  integrity sha512-pZZoSxcCYco+DIKBTimr67J6Hy+EYGZDY/HCWC+iAEA9h1ByhMXAIVUXMcMFpOCxQ/xjXmPI2MkDL5HRm5eFrQ==
+js-yaml@^3.13.1:
+  version "3.13.1"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.1.tgz#aff151b30bfdfa8e49e05da22e7415e9dfa37847"
+  integrity sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"


### PR DESCRIPTION
Upgrades js-yaml to ^3.13.1 to resolve security vulnerabilities relating to [an unsafe state of the `load()` function](https://github.com/nodeca/js-yaml/pull/480) in versions ≥ 3.13.0.

This has actually been [merged in the main `@rails/webpacker`](https://github.com/rails/webpacker/pull/2029) repository, but has not been released (see [#2204](https://github.com/rails/webpacker/issues/2204)).

I will be publishing a release on this repository following the merge as `3.6.1`.

 _NOTE: This has since been resolved in `@rails/webpacker` 4.x branches; this is a temporary measure for projects not ready for the full webpacker v3.x --> v4.x upgrade._